### PR TITLE
fix: remove hardcoded DB credentials from docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in real values. Never commit .env.
+MSSQL_SA_PASSWORD=your_strong_password_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
       - "8080:80"
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - ConnectionStrings__DefaultConnection=Server=sqlserver;Database=dg-invest;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=True;
+      - ConnectionStrings__DefaultConnection=Server=sqlserver;Database=dg-invest;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;
     restart: on-failure
 
   sqlserver:
     image: mcr.microsoft.com/azure-sql-edge:latest
     container_name: my-sqlserver
     environment:
-      MSSQL_SA_PASSWORD: YourStrong!Passw0rd
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
       ACCEPT_EULA: "1"
     ports:
       - "1434:1433"


### PR DESCRIPTION
## Summary
- Replaced plaintext `YourStrong!Passw0rd` with `${MSSQL_SA_PASSWORD}` env var in both the app and sqlserver service entries
- Added `.env.example` as a safe template — copy to `.env` and fill in real values before running `docker compose up`

## Security impact
Prevents the SA password from being committed to version control and exposed to anyone with repo access.

## Test plan
- [ ] Copy `.env.example` → `.env`, set a real password
- [ ] `docker compose up` — both containers start and the API connects to SQL Server

🤖 Generated with [Claude Code](https://claude.com/claude-code)