### PR TITLE
fix: restore random password generation for new users

### DIFF
--- a/api/api/Users/Commands/CreateUserCommand.cs
+++ b/api/api/Users/Commands/CreateUserCommand.cs
@@ -59,7 +59,7 @@ public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, Respo
         if (await _userRepository.IsUnique(request.Email))
             return new Response("Email already exists", false);
 
-        var randomPassword = "111111"; //_passwordHelper.RandomPassword();
+        var randomPassword = _passwordHelper.RandomPassword();
 
         var user = new User(request.FullName,
                             request.Email,


### PR DESCRIPTION
## Summary
- Replaced hardcoded `"111111"` with the existing `_passwordHelper.RandomPassword()` helper that was accidentally commented out

## Security impact
All newly created users were receiving the same weak password (`111111`), making every account trivially guessable until the user changed it.

## Test plan
- [ ] Create a new user via `POST /api/user/create`
- [ ] Confirm the welcome email contains a randomly generated password
- [ ] Confirm login works with that password

🤖 Generated with [Claude Code](https://claude.com/claude-code)