### PR TITLE
fix: require authentication on POST /api/crypto/create-crypto

### DIFF
--- a/api/api/Controllers/CryptoController.cs
+++ b/api/api/Controllers/CryptoController.cs
@@ -31,7 +31,6 @@ public class CryptoController : ControllerBase
     // }
 
     [HttpPost("create-crypto")]
-    [AllowAnonymous]
     public async Task<ActionResult> CreateCrypto([FromBody] CreateCryptoCommand command)
     {
 


### PR DESCRIPTION
## Summary
- Removed `[AllowAnonymous]` from the `create-crypto` endpoint so it inherits the controller-level `[Authorize]` attribute

## Security impact
Any unauthenticated caller could create crypto records in the database. This closes the open write endpoint.

## Test plan
- [ ] `POST /api/crypto/create-crypto` without a token → `401 Unauthorized`
- [ ] `POST /api/crypto/create-crypto` with a valid JWT → succeeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)