### PR TITLE
fix: raise minimum password length from 6 to 8 characters

### DIFF
--- a/api/api/Authentication/Commands/AuthenticateCommand.cs
+++ b/api/api/Authentication/Commands/AuthenticateCommand.cs
@@ -13,7 +13,7 @@ public class AuthenticateCommandValidator : AbstractValidator<AuthenticateComman
     public AuthenticateCommandValidator()
     {
         RuleFor(x => x.Email).NotEmpty().EmailAddress();
-        RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
+        RuleFor(x => x.Password).NotEmpty().MinimumLength(8);
     }
 }
 public class AuthenticateHandler : IRequestHandler<AuthenticateCommand, Response>


### PR DESCRIPTION
## Summary
- Updated `AuthenticateCommandValidator` to enforce `MinimumLength(8)` instead of 6

## Security impact
Six-character passwords are well within brute-force range. Eight is a modest but meaningful improvement; consider raising further (12+) in a follow-up.

## Test plan
- [ ] `POST /api/authentication/login` with a 7-char password → `400` validation error
- [ ] `POST /api/authentication/login` with an 8-char password → proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)