### PR TITLE
fix: make BlobStorageService resilient to missing/invalid connection strings

### DIFF
--- a/api/api/AzureStorage/Blob/BlobStorageService.cs
+++ b/api/api/AzureStorage/Blob/BlobStorageService.cs
@@ -9,19 +9,43 @@ namespace api.AzureStorage.Blob;
 
 public class BlobStorageService : IBlobStorageService
 {
-    private readonly BlobServiceClient _blobServiceClient;
+    private BlobServiceClient? _blobServiceClient;
     private readonly AzureStorageSettings _settings;
     private readonly ILogger<BlobStorageService> _logger;
 
     public BlobStorageService(IOptions<AzureStorageSettings> settings, ILogger<BlobStorageService> logger)
     {
         _settings = settings.Value;
-        _blobServiceClient = new BlobServiceClient(_settings.ConnectionString);
         _logger = logger;
+        TryInitializeClient();
+    }
+
+    private void TryInitializeClient()
+    {
+        if (string.IsNullOrWhiteSpace(_settings.ConnectionString))
+        {
+            _logger.LogWarning("AzureStorage ConnectionString is not configured. Blob storage operations will be skipped.");
+            return;
+        }
+
+        try
+        {
+            _blobServiceClient = new BlobServiceClient(_settings.ConnectionString);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to initialize BlobServiceClient. Blob storage operations will be skipped.");
+        }
     }
 
     public async Task AppendLogAsync<T>(string containerName, string blobPath, T entry, CancellationToken cancellationToken = default)
     {
+        if (_blobServiceClient == null)
+        {
+            _logger.LogDebug("Blob storage not configured, skipping append log to {Container}/{Blob}", containerName, blobPath);
+            return;
+        }
+
         try
         {
             var container = _blobServiceClient.GetBlobContainerClient(containerName);
@@ -45,6 +69,13 @@ public class BlobStorageService : IBlobStorageService
     public async Task<List<T>> ReadLogsAsync<T>(string containerName, string blobPath, CancellationToken cancellationToken = default)
     {
         var results = new List<T>();
+
+        if (_blobServiceClient == null)
+        {
+            _logger.LogDebug("Blob storage not configured, skipping read log from {Container}/{Blob}", containerName, blobPath);
+            return results;
+        }
+
         try
         {
             var container = _blobServiceClient.GetBlobContainerClient(containerName);


### PR DESCRIPTION
Fixes function crash when `AzureStorageSettings:ConnectionString` is missing or invalid. Blob storage operations now gracefully skip instead of throwing on DI construction.

Previously the function failed to start entirely if the connection string was misconfigured.