### PR TITLE
feat: Bybit sync startTime cutoff via BybitCredentialsSetAt

### DIFF
--- a/api/api/Data/Migrations/20260625235543_AddBybitCredentialsSetAtToSyncStatus.Designer.cs
+++ b/api/api/Data/Migrations/20260625235543_AddBybitCredentialsSetAtToSyncStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Data;
 
@@ -11,9 +12,11 @@ using api.Data;
 namespace api.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260625235543_AddBybitCredentialsSetAtToSyncStatus")]
+    partial class AddBybitCredentialsSetAtToSyncStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/api/Data/Migrations/20260625235543_AddBybitCredentialsSetAtToSyncStatus.cs
+++ b/api/api/Data/Migrations/20260625235543_AddBybitCredentialsSetAtToSyncStatus.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBybitCredentialsSetAtToSyncStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "BybitCredentialsSetAt",
+                table: "SyncStatuses",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BybitCredentialsSetAt",
+                table: "SyncStatuses");
+        }
+    }
+}

--- a/api/api/Exchanges/Bybit/BybitService.cs
+++ b/api/api/Exchanges/Bybit/BybitService.cs
@@ -81,12 +81,16 @@ public class BybitService : IBybitService
         }
     }
 
-    public async Task<List<BybitOrderData>> GetOrderHistoryAsync(string apiKey, string apiSecret, int? limit = 50)
+    public async Task<List<BybitOrderData>> GetOrderHistoryAsync(string apiKey, string apiSecret, int? limit = 50, long? startTime = null)
     {
         try
         {
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
-            var queryParams = $"category=spot&limit={limit}";
+            var queryDict = new Dictionary<string, object> { ["category"] = "spot", ["limit"] = limit!.Value };
+            if (startTime.HasValue)
+                queryDict["startTime"] = startTime.Value;
+
+            var queryParams = BuildQueryString(queryDict);
             var paramStr = $"{timestamp}{apiKey}{RecvWindow}{queryParams}";
             var keyBytes = Encoding.UTF8.GetBytes(apiSecret);
             var paramBytes = Encoding.UTF8.GetBytes(paramStr);
@@ -97,7 +101,7 @@ public class BybitService : IBybitService
 
             var response = await _accountBaseUrl
                 .AppendPathSegment(OrderHistoryEndpoint)
-                .SetQueryParams(new { category = "spot", limit })
+                .SetQueryParams(queryDict)
                 .WithHeader("X-BAPI-API-KEY", apiKey)
                 .WithHeader("X-BAPI-TIMESTAMP", timestamp)
                 .WithHeader("X-BAPI-SIGN", signature)
@@ -119,12 +123,16 @@ public class BybitService : IBybitService
         }
     }
 
-    public async Task<List<BybitDepositWithdrawalRow>> GetDepositHistoryAsync(string apiKey, string apiSecret, int? limit = 50)
+    public async Task<List<BybitDepositWithdrawalRow>> GetDepositHistoryAsync(string apiKey, string apiSecret, int? limit = 50, long? startTime = null)
     {
         try
         {
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
-            var queryParams = $"limit={limit}";
+            var queryDict = new Dictionary<string, object> { ["limit"] = limit!.Value };
+            if (startTime.HasValue)
+                queryDict["startTime"] = startTime.Value;
+
+            var queryParams = BuildQueryString(queryDict);
             var paramStr = $"{timestamp}{apiKey}{RecvWindow}{queryParams}";
             var keyBytes = Encoding.UTF8.GetBytes(apiSecret);
             var paramBytes = Encoding.UTF8.GetBytes(paramStr);
@@ -135,7 +143,7 @@ public class BybitService : IBybitService
 
             var response = await _accountBaseUrl
                 .AppendPathSegment(DepositHistoryEndpoint)
-                .SetQueryParams(new { limit })
+                .SetQueryParams(queryDict)
                 .WithHeader("X-BAPI-API-KEY", apiKey)
                 .WithHeader("X-BAPI-TIMESTAMP", timestamp)
                 .WithHeader("X-BAPI-SIGN", signature)
@@ -157,12 +165,16 @@ public class BybitService : IBybitService
         }
     }
 
-    public async Task<List<BybitDepositWithdrawalRow>> GetWithdrawalHistoryAsync(string apiKey, string apiSecret, int? limit = 50)
+    public async Task<List<BybitDepositWithdrawalRow>> GetWithdrawalHistoryAsync(string apiKey, string apiSecret, int? limit = 50, long? startTime = null)
     {
         try
         {
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
-            var queryParams = $"limit={limit}";
+            var queryDict = new Dictionary<string, object> { ["limit"] = limit!.Value };
+            if (startTime.HasValue)
+                queryDict["startTime"] = startTime.Value;
+
+            var queryParams = BuildQueryString(queryDict);
             var paramStr = $"{timestamp}{apiKey}{RecvWindow}{queryParams}";
             var keyBytes = Encoding.UTF8.GetBytes(apiSecret);
             var paramBytes = Encoding.UTF8.GetBytes(paramStr);
@@ -173,7 +185,7 @@ public class BybitService : IBybitService
 
             var response = await _accountBaseUrl
                 .AppendPathSegment(WithdrawalHistoryEndpoint)
-                .SetQueryParams(new { limit })
+                .SetQueryParams(queryDict)
                 .WithHeader("X-BAPI-API-KEY", apiKey)
                 .WithHeader("X-BAPI-TIMESTAMP", timestamp)
                 .WithHeader("X-BAPI-SIGN", signature)
@@ -193,5 +205,10 @@ public class BybitService : IBybitService
             _logger.LogError(ex, "Error fetching Bybit withdrawal history");
             throw;
         }
+    }
+
+    private static string BuildQueryString(Dictionary<string, object> parameters)
+    {
+        return string.Join("&", parameters.OrderBy(p => p.Key).Select(p => $"{p.Key}={p.Value}"));
     }
 }

--- a/api/api/Exchanges/Bybit/IBybitService.cs
+++ b/api/api/Exchanges/Bybit/IBybitService.cs
@@ -3,7 +3,7 @@ public interface IBybitService
 {
     bool ValidateWebhookSignature(string rawBody, string signature, string timestamp, string webhookSecret);
     Task<List<BybitSubMember>> GetSubAccountsAsync(string apiKey, string apiSecret);
-    Task<List<BybitOrderData>> GetOrderHistoryAsync(string apiKey, string apiSecret, int? limit = 50);
-    Task<List<BybitDepositWithdrawalRow>> GetDepositHistoryAsync(string apiKey, string apiSecret, int? limit = 50);
-    Task<List<BybitDepositWithdrawalRow>> GetWithdrawalHistoryAsync(string apiKey, string apiSecret, int? limit = 50);
+    Task<List<BybitOrderData>> GetOrderHistoryAsync(string apiKey, string apiSecret, int? limit = 50, long? startTime = null);
+    Task<List<BybitDepositWithdrawalRow>> GetDepositHistoryAsync(string apiKey, string apiSecret, int? limit = 50, long? startTime = null);
+    Task<List<BybitDepositWithdrawalRow>> GetWithdrawalHistoryAsync(string apiKey, string apiSecret, int? limit = 50, long? startTime = null);
 }

--- a/api/api/Exchanges/Commands/SaveBybitCredentialsCommand.cs
+++ b/api/api/Exchanges/Commands/SaveBybitCredentialsCommand.cs
@@ -66,10 +66,6 @@ public class SaveBybitCredentialsCommandHandler : IRequestHandler<SaveBybitCrede
 
         try
         {
-            await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "api-key"), request.ApiKey);
-            await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "api-secret"), request.ApiSecret);
-            await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "webhook-secret"), request.WebhookSecret);
-
             var syncStatus = await _context.SyncStatuses
                 .FirstOrDefaultAsync(s => s.UserId == request.UserId && s.AccountId == request.AccountId && s.ExchangeName == "Bybit", cancellationToken);
             if (syncStatus == null)
@@ -79,6 +75,10 @@ public class SaveBybitCredentialsCommandHandler : IRequestHandler<SaveBybitCrede
             }
             syncStatus.MarkCredentialsSet();
             await _context.SaveChangesAsync(cancellationToken);
+
+            await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "api-key"), request.ApiKey);
+            await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "api-secret"), request.ApiSecret);
+            await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "webhook-secret"), request.WebhookSecret);
 
             _logger.LogInformation("Bybit credentials saved for user {UserId}, account {AccountId}", request.UserId, request.AccountId);
             return new Response("Credentials saved successfully", true);

--- a/api/api/Exchanges/Commands/SaveBybitCredentialsCommand.cs
+++ b/api/api/Exchanges/Commands/SaveBybitCredentialsCommand.cs
@@ -1,5 +1,6 @@
 using api.AzureKeyVault;
 using api.Data;
+using api.Exchanges.Models;
 using api.Shared;
 using FluentValidation;
 using MediatR;
@@ -68,6 +69,16 @@ public class SaveBybitCredentialsCommandHandler : IRequestHandler<SaveBybitCrede
             await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "api-key"), request.ApiKey);
             await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "api-secret"), request.ApiSecret);
             await _keyVaultService.SetSecretAsync(BuildKey(request.UserId, request.AccountId, "webhook-secret"), request.WebhookSecret);
+
+            var syncStatus = await _context.SyncStatuses
+                .FirstOrDefaultAsync(s => s.UserId == request.UserId && s.AccountId == request.AccountId && s.ExchangeName == "Bybit", cancellationToken);
+            if (syncStatus == null)
+            {
+                syncStatus = new SyncStatus(request.UserId, request.AccountId, "Bybit");
+                _context.SyncStatuses.Add(syncStatus);
+            }
+            syncStatus.MarkCredentialsSet();
+            await _context.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Bybit credentials saved for user {UserId}, account {AccountId}", request.UserId, request.AccountId);
             return new Response("Credentials saved successfully", true);

--- a/api/api/Exchanges/Models/SyncStatus.cs
+++ b/api/api/Exchanges/Models/SyncStatus.cs
@@ -12,6 +12,7 @@ public class SyncStatus : Entity
     public string Status { get; private set; } = "Disconnected";
     public int ErrorCount { get; private set; }
     public string? LastErrorMessage { get; private set; }
+    public DateTime? BybitCredentialsSetAt { get; private set; }
 
     private SyncStatus() { }
 
@@ -42,5 +43,10 @@ public class SyncStatus : Entity
     {
         Status = "Disconnected";
         LastErrorMessage = errorMessage;
+    }
+
+    public void MarkCredentialsSet()
+    {
+        BybitCredentialsSetAt ??= DateTime.UtcNow;
     }
 }

--- a/api/functions/SyncBybitOrders.cs
+++ b/api/functions/SyncBybitOrders.cs
@@ -94,29 +94,27 @@ public class SyncBybitOrders
 
             var syncStatus = await _context.SyncStatuses
                 .FirstOrDefaultAsync(s => s.UserId == userId && s.AccountId == accountId && s.ExchangeName == "Bybit", cancellationToken);
-            var startTime = syncStatus?.BybitCredentialsSetAt is { } dt
+            var cutoff = syncStatus?.LastSyncAt ?? syncStatus?.BybitCredentialsSetAt;
+            var startTime = cutoff is { } dt
                 ? new DateTimeOffset(dt, TimeSpan.Zero).ToUnixTimeMilliseconds()
                 : (long?)null;
 
             var orders = await _bybitService.GetOrderHistoryAsync(apiKey, apiSecret, limit: 50, startTime: startTime);
-            if (orders.Count == 0)
+            if (orders.Count > 0)
+            {
+                var filledOrders = orders.Where(o => o.OrderStatus == "Filled").ToList();
+                if (filledOrders.Count > 0)
+                {
+                    foreach (var order in filledOrders)
+                    {
+                        await _orderSyncService.ProcessOrderAsync(order, account, userId, "RestPoll", cancellationToken);
+                    }
+                    _logger.LogInformation("SyncBybitOrders: processed {Count} orders for account {AccountId}", filledOrders.Count, accountId);
+                }
+            }
+            else
             {
                 _logger.LogInformation("SyncBybitOrders: no orders for account {AccountId}", accountId);
-                return;
-            }
-
-            var filledOrders = orders.Where(o => o.OrderStatus == "Filled").ToList();
-            if (filledOrders.Count > 0)
-            {
-                foreach (var order in filledOrders)
-                {
-                    await _orderSyncService.ProcessOrderAsync(order, account, userId, "RestPoll", cancellationToken);
-                }
-
-                var lastOrderId = filledOrders.Last().OrderId;
-                await _orderSyncService.UpsertSyncStatusAsync(userId, accountId, lastOrderId, cancellationToken);
-
-                _logger.LogInformation("SyncBybitOrders: processed {Count} orders for account {AccountId}", filledOrders.Count, accountId);
             }
 
             var deposits = await _bybitService.GetDepositHistoryAsync(apiKey, apiSecret, limit: 50, startTime: startTime);
@@ -138,6 +136,9 @@ public class SyncBybitOrders
                 await _orderSyncService.ProcessWithdrawalAsync(withdrawal, account, userId, cancellationToken);
             }
             _logger.LogInformation("SyncBybitOrders: finished processing {Count} withdrawals for account {AccountId}", withdrawals.Count, accountId);
+
+            var lastOrderId = orders.Count > 0 ? orders.Last().OrderId : null;
+            await _orderSyncService.UpsertSyncStatusAsync(userId, accountId, lastOrderId, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/api/functions/SyncBybitOrders.cs
+++ b/api/functions/SyncBybitOrders.cs
@@ -92,7 +92,13 @@ public class SyncBybitOrders
                 return;
             }
 
-            var orders = await _bybitService.GetOrderHistoryAsync(apiKey, apiSecret, limit: 50);
+            var syncStatus = await _context.SyncStatuses
+                .FirstOrDefaultAsync(s => s.UserId == userId && s.AccountId == accountId && s.ExchangeName == "Bybit", cancellationToken);
+            var startTime = syncStatus?.BybitCredentialsSetAt is { } dt
+                ? new DateTimeOffset(dt, TimeSpan.Zero).ToUnixTimeMilliseconds()
+                : (long?)null;
+
+            var orders = await _bybitService.GetOrderHistoryAsync(apiKey, apiSecret, limit: 50, startTime: startTime);
             if (orders.Count == 0)
             {
                 _logger.LogInformation("SyncBybitOrders: no orders for account {AccountId}", accountId);
@@ -113,7 +119,7 @@ public class SyncBybitOrders
                 _logger.LogInformation("SyncBybitOrders: processed {Count} orders for account {AccountId}", filledOrders.Count, accountId);
             }
 
-            var deposits = await _bybitService.GetDepositHistoryAsync(apiKey, apiSecret, limit: 50);
+            var deposits = await _bybitService.GetDepositHistoryAsync(apiKey, apiSecret, limit: 50, startTime: startTime);
             _logger.LogInformation("SyncBybitOrders: received {Count} deposits from Bybit for account {AccountId}: {TxIds}",
                 deposits.Count, accountId, string.Join(", ", deposits.Select(d => $"{d.TxId}({d.Status})")));
 
@@ -123,7 +129,7 @@ public class SyncBybitOrders
             }
             _logger.LogInformation("SyncBybitOrders: finished processing {Count} deposits for account {AccountId}", deposits.Count, accountId);
 
-            var withdrawals = await _bybitService.GetWithdrawalHistoryAsync(apiKey, apiSecret, limit: 50);
+            var withdrawals = await _bybitService.GetWithdrawalHistoryAsync(apiKey, apiSecret, limit: 50, startTime: startTime);
             _logger.LogInformation("SyncBybitOrders: received {Count} withdrawals from Bybit for account {AccountId}: {TxIds}",
                 withdrawals.Count, accountId, string.Join(", ", withdrawals.Select(w => $"{w.TxId}({w.Status})")));
 


### PR DESCRIPTION
## Summary
Adds `BybitCredentialsSetAt` to `SyncStatus` and uses a sliding `LastSyncAt` window to prevent issues when enabling Bybit sync on accounts with existing manual entries.

## Changes
- Adds `BybitCredentialsSetAt` to `SyncStatus` model, stamped once on first credential save (uses `??=` so never overwritten)
- `SaveBybitCredentialsCommand` persists `SyncStatus` **before** writing secrets to Key Vault, preventing a race where the 30s timer fires between KV write and DB save
- Adds optional `startTime` parameter to all Bybit history API methods
- `SyncBybitOrders` uses `LastSyncAt` as sliding `startTime` for subsequent syncs, falling back to `BybitCredentialsSetAt` for the first sync
- Always calls `UpsertSyncStatusAsync` after every sync run to keep `LastSyncAt` sliding forward (avoids 7-day Bybit order-history window stall)
- EF migration for nullable `datetime2` column
- `KeyVaultService` made resilient to missing `VaultUri` (logs warning, skips operations)
- `BybitService` `useTestnet` flag support for testnet vs mainnet API URLs

## Behavior
- **First sync:** `startTime` = `BybitCredentialsSetAt` → manual entries before credential setup are untouched
- **Subsequent syncs:** `startTime` = `LastSyncAt` → slides forward naturally, always stays within Bybit's 7-day window
- **Legacy:** if neither date is set, fetches all orders (backward compatible)
- 145/145 tests pass