### PR TITLE
fix: defer deposit/withdrawal processing until Bybit status reaches Success

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ If a coin doesn't exist in your portfolio yet, the sync automatically creates it
 
 Deposits and withdrawals go through multiple statuses (Pending → Processing → Success / Failed). The sync tracks each status change and only affects your balances when the status reaches **Success**. Pending/failed transactions appear in your account history with a status badge so you always know what's happening.
 
+#### Bybit API status reference
+
+Non-Success entries are **skipped entirely** — no database records are created until Success is reached. This is intentional: creating a pending record would block the full creation path when Success arrives later (the dedup check would match the existing `ExchangeTransactionId` and return early without crediting the asset or updating balances).
+
+Status values as returned by the Bybit V5 API:
+
+| Operation | Success value | Type | Bybit docs |
+|-----------|--------------|------|------------|
+| **Deposit** | `"3"` (integer in JSON) | Numeric enum | [depositStatus](https://bybit-exchange.github.io/docs/v5/enum#depositstatus) |
+| **Withdrawal** | `"success"` (string literal) | String enum | [withdrawStatus](https://bybit-exchange.github.io/docs/v5/enum#withdrawstatus) |
+| **Order** | `"Filled"` (string literal) | String enum | [orderStatus](https://bybit-exchange.github.io/docs/v5/enum#orderstatus) |
+
+Deposit statuses: `0`=unknown, `1`=toBeConfirmed, `2`=processing, `3`=success, `4`=failed, `7`=rollback processing, plus sub-statuses `70011`–`10012`.  
+Withdrawal statuses: `SecurityCheck`, `Pending`, `success`, `CancelByUser`, `Reject`, `Fail`, `BlockchainConfirmed`, `MoreInformationRequired`.
+
 #### Data flow
 
 ```

--- a/api/api/Exchanges/Services/BybitOrderSyncService.cs
+++ b/api/api/Exchanges/Services/BybitOrderSyncService.cs
@@ -135,6 +135,13 @@ public class BybitOrderSyncService : IBybitOrderSyncService
             return;
         }
 
+        if (deposit.Status != "3")
+        {
+            _logger.LogInformation("Bybit sync: skipping non-success deposit {TxId} (Status: {Status})", deposit.TxId, deposit.Status);
+            await WriteDepositWithdrawalSyncLogAsync(deposit, symbol, userId, account.Id, "Skipped", $"Non-success status: {deposit.Status}", "BybitDeposit", logId, cancellationToken);
+            return;
+        }
+
         var cryptoAsset = await FindOrCreateCryptoAssetAsync(account, symbol, cancellationToken);
         if (cryptoAsset == null)
         {
@@ -147,9 +154,7 @@ public class BybitOrderSyncService : IBybitOrderSyncService
             ? parsed.DateTime
             : DateTime.UtcNow;
 
-        var depositPrice = deposit.Status == "Success"
-            ? await GetMarketPriceAsync(symbol, cancellationToken)
-            : 0;
+        var depositPrice = await GetMarketPriceAsync(symbol, cancellationToken);
 
         var depositCryptoTx = new CryptoTransaction(
             amount,
@@ -159,8 +164,7 @@ public class BybitOrderSyncService : IBybitOrderSyncService
             ETransactionType.TransferIn,
             0);
 
-        if (deposit.Status == "Success")
-            cryptoAsset.AddTransaction(depositCryptoTx);
+        cryptoAsset.AddTransaction(depositCryptoTx);
 
         var accountTx = new AccountTransaction(
             date: successAt,
@@ -221,6 +225,13 @@ public class BybitOrderSyncService : IBybitOrderSyncService
             return;
         }
 
+        if (!withdrawal.Status.Equals("success", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation("Bybit sync: skipping non-success withdrawal {TxId} (Status: {Status})", withdrawal.TxId, withdrawal.Status);
+            await WriteDepositWithdrawalSyncLogAsync(withdrawal, symbol, userId, account.Id, "Skipped", $"Non-success status: {withdrawal.Status}", "BybitWithdrawal", logId, cancellationToken);
+            return;
+        }
+
         var cryptoAsset = await FindOrCreateCryptoAssetAsync(account, symbol, cancellationToken);
         if (cryptoAsset == null)
         {
@@ -233,9 +244,7 @@ public class BybitOrderSyncService : IBybitOrderSyncService
             ? parsed.DateTime
             : DateTime.UtcNow;
 
-        var withdrawalPrice = withdrawal.Status == "Success"
-            ? await GetMarketPriceAsync(symbol, cancellationToken)
-            : 0;
+        var withdrawalPrice = await GetMarketPriceAsync(symbol, cancellationToken);
 
         var withdrawalCryptoTx = new CryptoTransaction(
             amount,
@@ -245,8 +254,7 @@ public class BybitOrderSyncService : IBybitOrderSyncService
             ETransactionType.TransferOut,
             fee);
 
-        if (withdrawal.Status == "Success")
-            cryptoAsset.AddTransaction(withdrawalCryptoTx);
+        cryptoAsset.AddTransaction(withdrawalCryptoTx);
 
         var accountTx = new AccountTransaction(
             date: successAt,


### PR DESCRIPTION
## Problem

Non-Success deposits/withdrawals (Pending, Processing) created an `AccountTransaction` with `ExchangeTransactionId` and `price=0`. When the status later changed to Success, the `existingTx` branch only updated `ExchangeStatus` and returned early — never crediting the crypto asset or account balance.

Additionally, the original code used `deposit.Status == "Success"` / `withdrawal.Status == "Success"` which never matched Bybit's actual response values.

## Fix

- Non-Success deposits/withdrawals are skipped entirely (logged via blob, no DB write)
- When Success status arrives later, no `existingTx` exists → full creation path runs with market price lookup, crypto asset credit, and balance update
- Removed dead conditional branches that depended on incorrect string comparisons

### Bybit V5 API status values (verified against official docs)

| | Success | Source |
|---|---|---|
| **Deposit** | `"3"` (integer in JSON) | [depositStatus enum](https://bybit-exchange.github.io/docs/v5/enum#depositstatus) |
| **Withdrawal** | `"success"` (string literal) | [withdrawStatus enum](https://bybit-exchange.github.io/docs/v5/enum#withdrawstatus) |

## Tested

145/145 tests pass.