### PR TITLE
fix: overwrite KV secrets instead of soft-deleting on credential delete

### DIFF
--- a/api/api/Exchanges/Commands/DeleteCredentialsCommand.cs
+++ b/api/api/Exchanges/Commands/DeleteCredentialsCommand.cs
@@ -38,12 +38,12 @@ public class DeleteCredentialsCommandHandler : IRequestHandler<DeleteCredentials
 
         try
         {
-            await _keyVaultService.DeleteSecretAsync(
-                SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "api-key"));
-            await _keyVaultService.DeleteSecretAsync(
-                SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "api-secret"));
-            await _keyVaultService.DeleteSecretAsync(
-                SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "webhook-secret"));
+            await _keyVaultService.SetSecretAsync(
+                SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "api-key"), string.Empty);
+            await _keyVaultService.SetSecretAsync(
+                SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "api-secret"), string.Empty);
+            await _keyVaultService.SetSecretAsync(
+                SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "webhook-secret"), string.Empty);
 
             _logger.LogInformation("Bybit credentials deleted for user {UserId}, account {AccountId}", request.UserId, request.AccountId);
             return new Response("Credentials deleted successfully", true);


### PR DESCRIPTION
## Problem
`DeleteCredentialsCommand` calls `StartDeleteSecretAsync` which soft-deletes Key Vault secrets. Re-saving credentials with the same name fails with `ObjectIsDeletedButRecoverable` until the recovery period expires. End users would need Azure CLI access to purge — impractical.

## Fix
Replace `DeleteSecretAsync` with `SetSecretAsync("")` — overwrite secrets with an empty string instead of deleting. The sync already handles empty strings the same as null (skips the account). `SaveCredentials` can overwrite the empty string with new values without conflict.