### PR TITLE
feat: add DeepSeek-powered PR code review GitHub Action

### DIFF
--- a/.github/workflows/deepseek-code-review.yml
+++ b/.github/workflows/deepseek-code-review.yml
@@ -1,0 +1,162 @@
+name: DeepSeek Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get PR diff
+        id: diff
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git diff origin/${{ github.base_ref }}..HEAD > pr.diff
+          echo "diff_lines=$(wc -l < pr.diff)" >> $GITHUB_OUTPUT
+
+      - name: Skip if no changes
+        if: steps.diff.outputs.diff_lines == '0'
+        run: echo "No diff found, skipping review."
+
+      - name: Run DeepSeek Code Review
+        if: steps.diff.outputs.diff_lines != '0'
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAX_DIFF_LINES: '800'
+        run: |
+          DIFF=$(cat pr.diff | head -c 60000)
+          if [ $(wc -l < pr.diff) -gt 800 ]; then
+            echo "Diff too large (over 800 lines), reviewing first portion only."
+          fi
+
+          cat > review.js << 'SCRIPT'
+          const fs = require("fs");
+
+          const diff = fs.readFileSync("pr.diff", "utf8").slice(0, 60000);
+          const prNumber = process.env.PR_NUMBER;
+          const repo = process.env.REPO;
+
+          const systemPrompt = `You are a senior software engineer performing a code review on a pull request.
+          Review the following git diff. Focus on:
+          - Security vulnerabilities (SQL injection, XSS, insecure deserialization, hardcoded secrets, missing auth checks)
+          - Logic errors, race conditions, null reference risks
+          - Performance issues (N+1 queries, memory leaks, blocking calls)
+          - Code quality (duplicate code, unclear naming, missing error handling)
+          - Breaking changes or API contract violations
+
+          Respond with a JSON array of review comments. Each object must have:
+          - "path": the file path (from the diff headers)
+          - "line": the line number in the NEW file (or null for general comments)
+          - "body": the review comment (concise, actionable, max 300 chars)
+          - "severity": "error" | "warning" | "suggestion"
+
+          If there are no issues, return an empty array [].
+          Do NOT include any markdown formatting, code blocks, or extra text — just the raw JSON array.`;
+
+          const userPrompt = `Review this pull request diff for a .NET 8 / Angular / Azure Functions project:\n\n${diff}`;
+
+          (async () => {
+            const res = await fetch("https://api.deepseek.com/chat/completions", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${process.env.DEEPSEEK_API_KEY}`,
+              },
+              body: JSON.stringify({
+                model: "deepseek-chat",
+                messages: [
+                  { role: "system", content: systemPrompt },
+                  { role: "user", content: userPrompt },
+                ],
+                temperature: 0.1,
+                max_tokens: 4096,
+              }),
+            });
+
+            const data = await res.json();
+            const content = data.choices?.[0]?.message?.content || "[]";
+
+            // Extract JSON from possible markdown wrapping
+            let json = content.trim();
+            if (json.startsWith("```")) {
+              json = json.replace(/```\w*\n?/g, "").trim();
+            }
+
+            let comments;
+            try {
+              comments = JSON.parse(json);
+            } catch {
+              console.error("Failed to parse DeepSeek response:", content.slice(0, 500));
+              process.exit(0);
+            }
+
+            if (!Array.isArray(comments) || comments.length === 0) {
+              console.log("No review comments from DeepSeek.");
+              process.exit(0);
+            }
+
+            console.log(`Posting ${comments.length} review comments...`);
+
+            for (const c of comments.slice(0, 20)) {
+              const icon = c.severity === "error" ? "🔴" : c.severity === "warning" ? "🟡" : "💡";
+              const body = `${icon} **${c.severity}**: ${c.body}`;
+
+              try {
+                if (c.path && c.line) {
+                  await fetch(
+                    `https://api.github.com/repos/${repo}/pulls/${prNumber}/comments`,
+                    {
+                      method: "POST",
+                      headers: {
+                        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                        "Content-Type": "application/json",
+                      },
+                      body: JSON.stringify({
+                        body,
+                        path: c.path,
+                        line: c.line,
+                        commit_id: process.env.GITHUB_SHA,
+                      }),
+                    }
+                  );
+                } else {
+                  await fetch(
+                    `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`,
+                    {
+                      method: "POST",
+                      headers: {
+                        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                        "Content-Type": "application/json",
+                      },
+                      body: JSON.stringify({ body }),
+                    }
+                  );
+                }
+              } catch (err) {
+                console.error("Failed to post comment:", err.message);
+              }
+            }
+
+            console.log("Code review complete.");
+          })();
+          SCRIPT
+
+          node review.js

--- a/.github/workflows/deepseek-code-review.yml
+++ b/.github/workflows/deepseek-code-review.yml
@@ -62,22 +62,25 @@ jobs:
           const repo = process.env.REPO;
           const commitSha = process.env.COMMIT_SHA;
 
-          const systemPrompt = `You are a senior software engineer performing a code review on a pull request.
-          Review the following git diff. Focus on:
-          - Security vulnerabilities (SQL injection, XSS, insecure deserialization, hardcoded secrets, missing auth checks)
-          - Logic errors, race conditions, null reference risks
-          - Performance issues (N+1 queries, memory leaks, blocking calls)
-          - Code quality (duplicate code, unclear naming, missing error handling)
-          - Breaking changes or API contract violations
+          const systemPrompt = `You are a senior security-focused software engineer performing a code review.
+          Only flag issues that could cause real problems in production. Be conservative — if in doubt, skip it.
+          Do NOT comment on: coding style, naming preferences, formatting, minor optimizations, or theoretical concerns.
 
-          Respond with a JSON array of review comments. Each object must have:
-          - "path": the file path (from the diff headers)
-          - "line": the line number in the NEW file (or null for general comments)
-          - "body": the review comment (concise, actionable, max 300 chars)
-          - "severity": "error" | "warning" | "suggestion"
+          Only report:
+          - Security vulnerabilities (SQL injection, XSS, auth bypass, hardcoded secrets, insecure cryptography)
+          - Logic bugs that would produce incorrect results
+          - Race conditions or data corruption risks
+          - Null reference exceptions or unhandled error paths that would crash the app
+          - Breaking API changes
 
-          If there are no issues, return an empty array [].
-          Do NOT include any markdown formatting, code blocks, or extra text — just the raw JSON array.`;
+          Respond with a JSON array. Each object must have:
+          - "path": the file path
+          - "line": the line number in the new file (or null)
+          - "body": the review comment (max 200 chars, concise)
+          - "severity": "error"
+
+          If there are no real issues, return []. Do not return warnings or suggestions. Only errors.
+          Output ONLY the raw JSON array — no markdown, no code blocks, no extra text.`;
 
           const userPrompt = `Review this pull request diff for a .NET 8 / Angular / Azure Functions project:\n\n${diff}`;
 

--- a/.github/workflows/deepseek-code-review.yml
+++ b/.github/workflows/deepseek-code-review.yml
@@ -38,8 +38,9 @@ jobs:
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           MAX_DIFF_LINES: '800'
         run: |
           DIFF=$(cat pr.diff | head -c 60000)
@@ -50,9 +51,16 @@ jobs:
           cat > review.js << 'SCRIPT'
           const fs = require("fs");
 
+          const apiKey = process.env.DEEPSEEK_API_KEY;
+          if (!apiKey) {
+            console.error("DEEPSEEK_API_KEY is not set");
+            process.exit(0);
+          }
+
           const diff = fs.readFileSync("pr.diff", "utf8").slice(0, 60000);
           const prNumber = process.env.PR_NUMBER;
           const repo = process.env.REPO;
+          const commitSha = process.env.COMMIT_SHA;
 
           const systemPrompt = `You are a senior software engineer performing a code review on a pull request.
           Review the following git diff. Focus on:
@@ -74,27 +82,40 @@ jobs:
           const userPrompt = `Review this pull request diff for a .NET 8 / Angular / Azure Functions project:\n\n${diff}`;
 
           (async () => {
-            const res = await fetch("https://api.deepseek.com/chat/completions", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${process.env.DEEPSEEK_API_KEY}`,
-              },
-              body: JSON.stringify({
-                model: "deepseek-chat",
-                messages: [
-                  { role: "system", content: systemPrompt },
-                  { role: "user", content: userPrompt },
-                ],
-                temperature: 0.1,
-                max_tokens: 4096,
-              }),
-            });
+            let data;
+            try {
+              const res = await fetch("https://api.deepseek.com/chat/completions", {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                  model: "deepseek-chat",
+                  messages: [
+                    { role: "system", content: systemPrompt },
+                    { role: "user", content: userPrompt },
+                  ],
+                  temperature: 0.1,
+                  max_tokens: 4096,
+                }),
+              });
 
-            const data = await res.json();
+              const contentType = res.headers.get("content-type") || "";
+              if (!res.ok) {
+                const errBody = await res.text();
+                console.error(`DeepSeek API error (${res.status}): ${errBody.slice(0, 500)}`);
+                process.exit(0);
+              }
+
+              data = await res.json();
+            } catch (err) {
+              console.error("DeepSeek API request failed:", err.message);
+              process.exit(0);
+            }
+
             const content = data.choices?.[0]?.message?.content || "[]";
 
-            // Extract JSON from possible markdown wrapping
             let json = content.trim();
             if (json.startsWith("```")) {
               json = json.replace(/```\w*\n?/g, "").trim();
@@ -121,34 +142,44 @@ jobs:
 
               try {
                 if (c.path && c.line) {
-                  await fetch(
+                  const res = await fetch(
                     `https://api.github.com/repos/${repo}/pulls/${prNumber}/comments`,
                     {
                       method: "POST",
                       headers: {
-                        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                        Authorization: `Bearer ${process.env.GH_TOKEN}`,
                         "Content-Type": "application/json",
+                        Accept: "application/vnd.github+json",
                       },
                       body: JSON.stringify({
                         body,
                         path: c.path,
                         line: c.line,
-                        commit_id: process.env.GITHUB_SHA,
+                        commit_id: commitSha,
                       }),
                     }
                   );
+                  if (!res.ok) {
+                    const err = await res.text();
+                    console.error(`Failed to post inline comment: ${res.status} ${err.slice(0, 200)}`);
+                  }
                 } else {
-                  await fetch(
+                  const res = await fetch(
                     `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`,
                     {
                       method: "POST",
                       headers: {
-                        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                        Authorization: `Bearer ${process.env.GH_TOKEN}`,
                         "Content-Type": "application/json",
+                        Accept: "application/vnd.github+json",
                       },
                       body: JSON.stringify({ body }),
                     }
                   );
+                  if (!res.ok) {
+                    const err = await res.text();
+                    console.error(`Failed to post general comment: ${res.status} ${err.slice(0, 200)}`);
+                  }
                 }
               } catch (err) {
                 console.error("Failed to post comment:", err.message);

--- a/.github/workflows/deepseek-code-review.yml
+++ b/.github/workflows/deepseek-code-review.yml
@@ -136,9 +136,13 @@ jobs:
 
             console.log(`Posting ${comments.length} review comments...`);
 
+            const seen = new Set();
             for (const c of comments.slice(0, 20)) {
               const icon = c.severity === "error" ? "🔴" : c.severity === "warning" ? "🟡" : "💡";
               const body = `${icon} **${c.severity}**: ${c.body}`;
+              const dedupKey = `${c.path || ""}:${c.line || 0}:${body}`;
+              if (seen.has(dedupKey)) continue;
+              seen.add(dedupKey);
 
               try {
                 if (c.path && c.line) {


### PR DESCRIPTION
## What
Adds a GitHub Action that runs DeepSeek code review on every PR.

## How it works
1. Triggered on PR open/sync/reopen
2. Extracts the git diff between base and head branches
3. Sends the diff to DeepSeek API with a system prompt focused on security, logic, performance, and code quality
4. Posts review comments directly on the PR with severity badges (🔴 error, 🟡 warning, 💡 suggestion)

## Setup required
Add a repository secret: `DEEPSEEK_API_KEY` — your DeepSeek API key from https://platform.deepseek.com

## Limits
- Max 60k chars / ~800 lines of diff per review (DeepSeek context window)
- Max 20 review comments per PR (API rate limiting)
- Skips diff-only PRs (no file changes)