### PR TITLE
feat: add exchange-agnostic account list, detail, and transactions endpoints

### DIFF
--- a/api/api/Controllers/ExchangeController.cs
+++ b/api/api/Controllers/ExchangeController.cs
@@ -17,6 +17,42 @@ public class ExchangeController : ControllerBase
 
     public ExchangeController(IMediator mediator) => _mediator = mediator;
 
+    [HttpGet("accounts")]
+    public async Task<ActionResult<Response>> GetExchangeAccounts()
+    {
+        var userId = GetUserId();
+        if (userId == null)
+            return Unauthorized(new Response("Invalid user ID", false));
+
+        var result = await _mediator.Send(new GetExchangeAccountsQuery(userId.Value));
+        return Ok(result);
+    }
+
+    [HttpGet("{accountId:int}")]
+    public async Task<ActionResult<Response>> GetExchangeAccountDetail(int accountId)
+    {
+        var userId = GetUserId();
+        if (userId == null)
+            return Unauthorized(new Response("Invalid user ID", false));
+
+        var result = await _mediator.Send(new GetExchangeAccountDetailQuery(userId.Value, accountId));
+        if (!result.IsSuccess)
+            return BadRequest(result);
+
+        return Ok(result);
+    }
+
+    [HttpGet("{accountId:int}/transactions")]
+    public async Task<ActionResult<Response>> GetExchangeTransactions(int accountId, [FromQuery] int limit = 20)
+    {
+        var userId = GetUserId();
+        if (userId == null)
+            return Unauthorized(new Response("Invalid user ID", false));
+
+        var result = await _mediator.Send(new GetExchangeTransactionsQuery(userId.Value, accountId, limit));
+        return Ok(result);
+    }
+
     [HttpPost("bybit/credentials")]
     public async Task<ActionResult<Response>> SaveBybitCredentials([FromBody] SaveBybitCredentialsRequest request)
     {

--- a/api/api/Exchanges/Queries/GetExchangeAccountDetailQuery.cs
+++ b/api/api/Exchanges/Queries/GetExchangeAccountDetailQuery.cs
@@ -1,0 +1,94 @@
+using api.AzureKeyVault;
+using api.Data;
+using api.Exchanges.Commands;
+using api.Shared;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Exchanges.Queries;
+
+public record GetExchangeAccountDetailQuery(int UserId, int AccountId) : IRequest<Response>;
+
+public record ExchangeAccountDetailDto(
+    int AccountId,
+    string AccountTag,
+    List<ExchangeConnectionDto> Connections);
+
+public record ExchangeConnectionDto(
+    string ExchangeName,
+    string Status,
+    DateTime? LastSyncAt,
+    int ErrorCount,
+    string? LastErrorMessage,
+    bool HasApiKey,
+    bool HasApiSecret,
+    bool HasWebhookSecret);
+
+public class GetExchangeAccountDetailQueryHandler : IRequestHandler<GetExchangeAccountDetailQuery, Response>
+{
+    private readonly DataContext _context;
+    private readonly IKeyVaultService _keyVaultService;
+
+    public GetExchangeAccountDetailQueryHandler(DataContext context, IKeyVaultService keyVaultService)
+    {
+        _context = context;
+        _keyVaultService = keyVaultService;
+    }
+
+    public async Task<Response> Handle(GetExchangeAccountDetailQuery request, CancellationToken cancellationToken)
+    {
+        var account = await _context.Accounts
+            .Where(a => a.Id == request.AccountId && a.UserId == request.UserId)
+            .Select(a => new { a.Id, a.SubaccountTag })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (account == null)
+            return new Response("Account not found", false, 404);
+
+        var syncStatuses = await _context.SyncStatuses
+            .Where(s => s.UserId == request.UserId && s.AccountId == request.AccountId)
+            .ToListAsync(cancellationToken);
+
+        // For each exchange with a SyncStatus, check credentials in Key Vault
+        var connections = new List<ExchangeConnectionDto>();
+
+        foreach (var status in syncStatuses)
+        {
+            var hasApiKey = !string.IsNullOrEmpty(
+                await _keyVaultService.GetSecretAsync(SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "api-key")));
+            var hasApiSecret = !string.IsNullOrEmpty(
+                await _keyVaultService.GetSecretAsync(SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "api-secret")));
+            var hasWebhookSecret = !string.IsNullOrEmpty(
+                await _keyVaultService.GetSecretAsync(SaveBybitCredentialsCommandHandler.BuildKey(request.UserId, request.AccountId, "webhook-secret")));
+
+            connections.Add(new ExchangeConnectionDto(
+                status.ExchangeName,
+                status.Status,
+                status.LastSyncAt,
+                status.ErrorCount,
+                status.LastErrorMessage,
+                hasApiKey,
+                hasApiSecret,
+                hasWebhookSecret));
+        }
+
+        // If no sync status exists, still report the account as NotConfigured
+        if (connections.Count == 0)
+        {
+            connections.Add(new ExchangeConnectionDto(
+                "Bybit",
+                "NotConfigured",
+                null,
+                0,
+                null,
+                false,
+                false,
+                false));
+        }
+
+        return new Response("ok", true, new ExchangeAccountDetailDto(
+            account.Id,
+            account.SubaccountTag,
+            connections));
+    }
+}

--- a/api/api/Exchanges/Queries/GetExchangeAccountsQuery.cs
+++ b/api/api/Exchanges/Queries/GetExchangeAccountsQuery.cs
@@ -1,0 +1,77 @@
+using api.Data;
+using api.Shared;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Exchanges.Queries;
+
+public record GetExchangeAccountsQuery(int UserId) : IRequest<Response>;
+
+public record ExchangeAccountDto(
+    int AccountId,
+    string AccountTag,
+    string ExchangeName,
+    string Status,
+    DateTime? LastSyncAt,
+    int ErrorCount,
+    string? LastErrorMessage);
+
+public class GetExchangeAccountsQueryHandler : IRequestHandler<GetExchangeAccountsQuery, Response>
+{
+    private readonly DataContext _context;
+
+    public GetExchangeAccountsQueryHandler(DataContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Response> Handle(GetExchangeAccountsQuery request, CancellationToken cancellationToken)
+    {
+        var accounts = await _context.Accounts
+            .Where(a => a.UserId == request.UserId)
+            .Select(a => new { a.Id, a.SubaccountTag })
+            .ToListAsync(cancellationToken);
+
+        var syncStatuses = await _context.SyncStatuses
+            .Where(s => s.UserId == request.UserId)
+            .Select(s => new { s.AccountId, s.ExchangeName, s.Status, s.LastSyncAt, s.ErrorCount, s.LastErrorMessage })
+            .ToListAsync(cancellationToken);
+
+        var statusLookup = syncStatuses
+            .GroupBy(s => s.AccountId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var result = new List<ExchangeAccountDto>();
+
+        foreach (var account in accounts)
+        {
+            if (statusLookup.TryGetValue(account.Id, out var statuses))
+            {
+                foreach (var s in statuses)
+                {
+                    result.Add(new ExchangeAccountDto(
+                        account.Id,
+                        account.SubaccountTag,
+                        s.ExchangeName,
+                        s.Status,
+                        s.LastSyncAt,
+                        s.ErrorCount,
+                        s.LastErrorMessage));
+                }
+            }
+            else
+            {
+                result.Add(new ExchangeAccountDto(
+                    account.Id,
+                    account.SubaccountTag,
+                    string.Empty,
+                    "NotConfigured",
+                    null,
+                    0,
+                    null));
+            }
+        }
+
+        return new Response("ok", true, result);
+    }
+}

--- a/api/api/Exchanges/Queries/GetExchangeTransactionsQuery.cs
+++ b/api/api/Exchanges/Queries/GetExchangeTransactionsQuery.cs
@@ -1,0 +1,60 @@
+using api.Data;
+using api.Shared;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Exchanges.Queries;
+
+public record GetExchangeTransactionsQuery(int UserId, int AccountId, int Limit = 20) : IRequest<Response>;
+
+public record ExchangeTransactionDto(
+    int Id,
+    DateTime Date,
+    string Type,
+    string Asset,
+    decimal Amount,
+    decimal Price,
+    decimal Fee,
+    string? ExchangeName,
+    string? ExchangeStatus,
+    string Notes);
+
+public class GetExchangeTransactionsQueryHandler : IRequestHandler<GetExchangeTransactionsQuery, Response>
+{
+    private readonly DataContext _context;
+
+    public GetExchangeTransactionsQueryHandler(DataContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Response> Handle(GetExchangeTransactionsQuery request, CancellationToken cancellationToken)
+    {
+        var accountExists = await _context.Accounts
+            .AnyAsync(a => a.Id == request.AccountId && a.UserId == request.UserId, cancellationToken);
+
+        if (!accountExists)
+            return new Response("Account not found", false, 404);
+
+        var transactions = await _context.AccountTransactions
+            .Where(t => EF.Property<int>(t, "AccountId") == request.AccountId
+                        && t.ExchangeName != null
+                        && t.ExchangeName != "")
+            .OrderByDescending(t => t.Date)
+            .Take(request.Limit)
+            .Select(t => new ExchangeTransactionDto(
+                t.Id,
+                t.Date,
+                t.TransactionType.ToString(),
+                t.CryptoAsset != null ? t.CryptoAsset.Symbol : "-",
+                t.Amount,
+                t.CryptoCurrentPrice,
+                t.Fee,
+                t.ExchangeName,
+                t.ExchangeStatus,
+                t.Notes))
+            .ToListAsync(cancellationToken);
+
+        return new Response("ok", true, transactions);
+    }
+}


### PR DESCRIPTION
Part of #223

Adds three new exchange-agnostic endpoints:

### `GET /Exchange/accounts`
Returns all user accounts with their exchange connection status (Connected, Disconnected, Error, NotConfigured). Exchange-agnostic — supports multiple exchanges per account in the future.

### `GET /Exchange/{accountId}`
Returns detail for one account: sync status + whether API key/secret/webhook are configured. Combines data from SyncStatus table and Key Vault.

### `GET /Exchange/{accountId}/transactions`
Returns the most recent N exchange-synced transactions (orders, deposits, withdrawals) for a specific account.

All existing Bybit-specific endpoints (`/Exchange/bybit/...`) are preserved.

145/145 tests pass.