### PR TITLE
feat: add pagination, filtering, and time display to account transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,35 @@ Every synced event is recorded in two places:
 The sync is idempotent — running it multiple times will never create duplicates. If you see duplicates, check the `ExchangeOrderId` or `ExchangeTransactionId` values in the database for collisions.
 
 ---
+
+### Account transactions
+
+The **Account** page displays your transaction history with filtering, pagination, and real-time balance updates.
+
+**Landing page:** Shows the 20 most recent transactions across all categories (deposits, withdrawals, buys, sells), grouped by date with the latest date group first. Each transaction displays its time.
+
+**Filters** (server-side, combine with AND logic):
+
+| Filter | Description |
+|--------|-------------|
+| **Text search** | Searches across exchange name, notes, crypto symbol, and transaction type label (e.g., typing "bybit" finds all Bybit-synced trades) |
+| **From date** | Show transactions on or after this date |
+| **To date** | Show transactions on or before this date |
+| **Status** | Filter by exchange status: All / Completed / Failed / Pending |
+
+**Examples:**
+- Filter by month: set From `2026-07-01`, To `2026-07-31`
+- See only failed syncs: set Status to `Failed`
+- Find all Bybit deposits from June: text `bybit` + From `2026-06-01` + To `2026-06-30`
+
+All filters reset to page 1 when changed. The date inputs and status dropdown can be used independently or together. A "Clear dates" button appears when dates are set.
+
+**Pagination:** 20 transactions per page. Previous/Next buttons appear when there are more than 20 results, showing the current page and total transaction count.
+
+**Persistence:** Non-Success exchange entries are **not created** in the database — they only appear in sync logs. Once status reaches Success, the transaction is recorded and appears here.
+
+---
+
 ### Project structure
 ```bash
 dg-invest/

--- a/api/api/Controllers/AccountController.cs
+++ b/api/api/Controllers/AccountController.cs
@@ -61,7 +61,10 @@ public class AccountController(IMediator mediator) : ControllerBase
     }
 
     [HttpGet("account-details")]
-    public async Task<ActionResult<Response>> GetAccountDetails()
+    public async Task<ActionResult<Response>> GetAccountDetails(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? filter = null)
     {
         var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
@@ -69,7 +72,7 @@ public class AccountController(IMediator mediator) : ControllerBase
             return Unauthorized(new Response("Invalid user ID", false));
         }
 
-        GetAccountDetailsQuery command = new(userId);
+        GetAccountDetailsQuery command = new(userId, page, pageSize, filter);
         var result = await _mediator.Send(command);
         if (!result.IsSuccess)
             return NotFound(result.Message);

--- a/api/api/Controllers/AccountController.cs
+++ b/api/api/Controllers/AccountController.cs
@@ -64,7 +64,10 @@ public class AccountController(IMediator mediator) : ControllerBase
     public async Task<ActionResult<Response>> GetAccountDetails(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 20,
-        [FromQuery] string? filter = null)
+        [FromQuery] string? filter = null,
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null,
+        [FromQuery] string? status = null)
     {
         var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
@@ -72,7 +75,7 @@ public class AccountController(IMediator mediator) : ControllerBase
             return Unauthorized(new Response("Invalid user ID", false));
         }
 
-        GetAccountDetailsQuery command = new(userId, page, pageSize, filter);
+        GetAccountDetailsQuery command = new(userId, page, pageSize, filter, startDate, endDate, status);
         var result = await _mediator.Send(command);
         if (!result.IsSuccess)
             return NotFound(result.Message);

--- a/api/api/Users/Dtos/UserDto.cs
+++ b/api/api/Users/Dtos/UserDto.cs
@@ -9,7 +9,8 @@ public record UserDto(
     Role Role,
     AccountDto? Account = null
 );
-public record AccountDto(int Id, decimal Balance, List<GroupedAccountTransactionsDto> GroupedAccountTransactions);
+public record AccountDto(int Id, decimal Balance, List<GroupedAccountTransactionsDto> GroupedAccountTransactions,
+    int TotalCount = 0, int Page = 1, int PageSize = 20, bool HasNextPage = false, bool HasPreviousPage = false);
 public record SubAccountDto(int Id, string Name);
 public record SimpleAccountDto(int Id, string SubaccountTag, decimal Balance, bool IsSelected);
 public record AccountTransactionDto(DateTime Date,

--- a/api/api/Users/Queries/GetAccountDetailsQuery.cs
+++ b/api/api/Users/Queries/GetAccountDetailsQuery.cs
@@ -1,4 +1,4 @@
-using api.Cache;
+using api.Cryptos.Models;
 using api.Data;
 using api.Shared;
 using api.Users.Dtos;
@@ -6,72 +6,105 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace api.Users.Queries;
-public record GetAccountDetailsQuery(int UserId) : IRequest<Response>;
+public record GetAccountDetailsQuery(int UserId, int Page = 1, int PageSize = 20, string? Filter = null) : IRequest<Response>;
 public class GetAccountDetailsQueryHandler : IRequestHandler<GetAccountDetailsQuery, Response>
 {
     private readonly DataContext _context;
     private readonly ILogger<GetAccountDetailsQueryHandler> _logger;
-    private readonly ICacheService _cacheService;
 
     public GetAccountDetailsQueryHandler(
         DataContext context,
-        ILogger<GetAccountDetailsQueryHandler> logger,
-        ICacheService cacheService)
+        ILogger<GetAccountDetailsQueryHandler> logger)
     {
         _context = context;
         _logger = logger;
-        _cacheService = cacheService;
     }
 
     public async Task<Response> Handle(GetAccountDetailsQuery request, CancellationToken cancellationToken)
     {
-        var cacheKey = $"{CacheKeyConstants.UserAccountDetails}{request.UserId}";
-        var absoluteExpiration = TimeSpan.FromMinutes(5);
-
-
-        var accountDto = await _cacheService.GetOrCreateAsync(cacheKey, async (ct) =>
+        var account = await _context.Accounts
+                                    .AsNoTracking()
+                                    .Where(u => u.UserId == request.UserId)
+                                    .Where(x => x.IsSelected == true)
+                                    .Include(x => x.AccountTransactions)
+                                    .ThenInclude(x => x.CryptoAsset)
+                                    .FirstOrDefaultAsync(cancellationToken);
+        if (account is null)
         {
-            var account = await _context.Accounts
-                                        .AsNoTracking()
-                                        .Where(u => u.UserId == request.UserId)
-                                        .Where(x => x.IsSelected == true)
-                                        .Include(x => x.AccountTransactions)
-                                        .ThenInclude(x => x.CryptoAsset)
-                                        .FirstOrDefaultAsync(cancellationToken);
-            if (account is null)
-            {
-                _logger.LogError("GetAccountDetailsQueryHandler: Account not found for user {UserId}", request.UserId);
-                return null;
-            }
+            _logger.LogError("GetAccountDetailsQueryHandler: Account not found for user {UserId}", request.UserId);
+            return new Response("Account not found", false, 404);
+        }
 
-            var groupedTransactions = account.AccountTransactions
-                .GroupBy(at => at.Date.Date)
-                .Select(g => new GroupedAccountTransactionsDto(
-                    g.Key,
-                    g.Select(at => new AccountTransactionDto(
-                        at.Date,
-                        at.TransactionType,
-                        at.Amount,
-                        at.ExchangeName,
-                        at.Notes,
-                        at.CryptoCurrentPrice,
-                        at.CryptoAsset?.Symbol.ToLower() ?? "",
-                        at.Fee,
-                        at.ExchangeStatus
-                    )).ToList()
-                ))
-                .OrderByDescending(g => g.Date)
-                .ToList();
+        var transactionsQuery = account.AccountTransactions.AsQueryable();
 
-            return new AccountDto(
-                account.Id,
-                account.Balance,
-                groupedTransactions
+        if (!string.IsNullOrWhiteSpace(request.Filter))
+        {
+            var filter = request.Filter.ToLower();
+            transactionsQuery = transactionsQuery.Where(at =>
+                (at.ExchangeName != null && at.ExchangeName.ToLower().Contains(filter)) ||
+                (at.Notes != null && at.Notes.ToLower().Contains(filter)) ||
+                (at.CryptoAsset != null && at.CryptoAsset.Symbol.ToLower().Contains(filter)) ||
+                GetTransactionTypeLabel(at.TransactionType).ToLower().Contains(filter)
             );
-        },
-        absoluteExpiration,
-        cancellationToken);
+        }
+
+        var sortedTransactions = transactionsQuery
+            .OrderByDescending(at => at.Date)
+            .ToList();
+
+        var totalCount = sortedTransactions.Count;
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize < 1 ? 20 : request.PageSize;
+
+        var pagedTransactions = sortedTransactions
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        var groupedTransactions = pagedTransactions
+            .GroupBy(at => at.Date.Date)
+            .Select(g => new GroupedAccountTransactionsDto(
+                g.Key,
+                g.Select(at => new AccountTransactionDto(
+                    at.Date,
+                    at.TransactionType,
+                    at.Amount,
+                    at.ExchangeName,
+                    at.Notes,
+                    at.CryptoCurrentPrice,
+                    at.CryptoAsset?.Symbol.ToLower() ?? "",
+                    at.Fee,
+                    at.ExchangeStatus
+                )).ToList()
+            ))
+            .OrderByDescending(g => g.Date)
+            .ToList();
+
+        var accountDto = new AccountDto(
+            account.Id,
+            account.Balance,
+            groupedTransactions,
+            totalCount,
+            page,
+            pageSize,
+            page * pageSize < totalCount,
+            page > 1
+        );
 
         return new Response("", true, accountDto);
+    }
+
+    private static string GetTransactionTypeLabel(EAccountTransactionType type)
+    {
+        return type switch
+        {
+            EAccountTransactionType.DepositFiat => "Deposit",
+            EAccountTransactionType.DepositCrypto => "Deposit Crypto",
+            EAccountTransactionType.WithdrawToBank => "Withdraw to Bank",
+            EAccountTransactionType.In => "Sell",
+            EAccountTransactionType.Out => "Buy",
+            EAccountTransactionType.WithdrawCrypto => "Withdraw Crypto",
+            _ => ""
+        };
     }
 }

--- a/api/api/Users/Queries/GetAccountDetailsQuery.cs
+++ b/api/api/Users/Queries/GetAccountDetailsQuery.cs
@@ -6,7 +6,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace api.Users.Queries;
-public record GetAccountDetailsQuery(int UserId, int Page = 1, int PageSize = 20, string? Filter = null) : IRequest<Response>;
+public record GetAccountDetailsQuery(int UserId, int Page = 1, int PageSize = 20, string? Filter = null, DateTime? StartDate = null, DateTime? EndDate = null, string? Status = null) : IRequest<Response>;
 public class GetAccountDetailsQueryHandler : IRequestHandler<GetAccountDetailsQuery, Response>
 {
     private readonly DataContext _context;
@@ -46,6 +46,29 @@ public class GetAccountDetailsQueryHandler : IRequestHandler<GetAccountDetailsQu
                 (at.CryptoAsset != null && at.CryptoAsset.Symbol.ToLower().Contains(filter)) ||
                 GetTransactionTypeLabel(at.TransactionType).ToLower().Contains(filter)
             );
+        }
+
+        if (request.StartDate.HasValue)
+        {
+            var start = request.StartDate.Value.Date;
+            transactionsQuery = transactionsQuery.Where(at => at.Date >= start);
+        }
+
+        if (request.EndDate.HasValue)
+        {
+            var end = request.EndDate.Value.Date.AddDays(1);
+            transactionsQuery = transactionsQuery.Where(at => at.Date < end);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Status))
+        {
+            var status = request.Status.ToLower();
+            if (status == "completed")
+                transactionsQuery = transactionsQuery.Where(at => at.ExchangeStatus == "3");
+            else if (status == "failed")
+                transactionsQuery = transactionsQuery.Where(at => at.ExchangeStatus == "4");
+            else if (status == "pending")
+                transactionsQuery = transactionsQuery.Where(at => at.ExchangeStatus != "3" && at.ExchangeStatus != "4");
         }
 
         var sortedTransactions = transactionsQuery

--- a/web-app/src/app/core/services/account.service.ts
+++ b/web-app/src/app/core/services/account.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment.development';
@@ -36,8 +36,14 @@ export class AccountService {
     return this.http.post<CustomRespose>(`${this.apiUrl}/create`, command);
   }
 
-  getSelectedAccount(): Observable<AccountDto> {
-    return this.http.get<AccountDto>(`${this.apiUrl}/account-details`);
+  getSelectedAccount(page: number = 1, pageSize: number = 20, filter: string = ''): Observable<AccountDto> {
+    let params = new HttpParams()
+      .append('page', page)
+      .append('pageSize', pageSize);
+    if (filter) {
+      params = params.append('filter', filter);
+    }
+    return this.http.get<AccountDto>(`${this.apiUrl}/account-details`, { params });
   }
 
   addCryptoAsset(request: AddCryptoAssetRequest): Observable<CustomRespose> {

--- a/web-app/src/app/core/services/account.service.ts
+++ b/web-app/src/app/core/services/account.service.ts
@@ -36,12 +36,21 @@ export class AccountService {
     return this.http.post<CustomRespose>(`${this.apiUrl}/create`, command);
   }
 
-  getSelectedAccount(page: number = 1, pageSize: number = 20, filter: string = ''): Observable<AccountDto> {
+  getSelectedAccount(page: number = 1, pageSize: number = 20, filter: string = '', startDate?: string, endDate?: string, status?: string): Observable<AccountDto> {
     let params = new HttpParams()
       .append('page', page)
       .append('pageSize', pageSize);
     if (filter) {
       params = params.append('filter', filter);
+    }
+    if (startDate) {
+      params = params.append('startDate', startDate);
+    }
+    if (endDate) {
+      params = params.append('endDate', endDate);
+    }
+    if (status) {
+      params = params.append('status', status);
     }
     return this.http.get<AccountDto>(`${this.apiUrl}/account-details`, { params });
   }

--- a/web-app/src/app/core/services/user.service.ts
+++ b/web-app/src/app/core/services/user.service.ts
@@ -33,6 +33,11 @@ export interface AccountDto {
   id: number;
   balance: number;
   groupedAccountTransactions: GroupedAccountTransactionsDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
 }
 
 export interface UserDto {

--- a/web-app/src/app/pages/cryptos/components/account-transaction-card/account-transaction-card.component.html
+++ b/web-app/src/app/pages/cryptos/components/account-transaction-card/account-transaction-card.component.html
@@ -30,6 +30,9 @@
             <span class="text-sm font-medium text-gray-900 dark:text-gray-100">
               {{ getTransactionTypeLabel(transaction.transactionType) }}
             </span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">
+              {{ transaction.date | date: 'h:mm a' }}
+            </span>
             @if (transaction.exchangeStatus) {
             <span [class]="'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ' + getStatusBadgeClass(transaction.exchangeStatus)">
               {{ getStatusLabel(transaction.exchangeStatus) }}

--- a/web-app/src/app/pages/cryptos/containers/account/account.component.html
+++ b/web-app/src/app/pages/cryptos/containers/account/account.component.html
@@ -42,6 +42,24 @@
       class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
       <app-account-transaction-card [groupedTransactionsNew]="account().groupedAccountTransactions">
       </app-account-transaction-card>
+
+      @if (account().totalCount > pageSize) {
+      <div class="flex items-center justify-between px-6 py-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
+        <span class="text-sm text-gray-600 dark:text-gray-400">
+          Page {{ account().page }} of {{ totalPages() }} ({{ account().totalCount }} transactions)
+        </span>
+        <div class="flex gap-2">
+          <button (click)="previousPage()" [disabled]="!account().hasPreviousPage"
+            class="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+            Previous
+          </button>
+          <button (click)="nextPage()" [disabled]="!account().hasNextPage"
+            class="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+            Next
+          </button>
+        </div>
+      </div>
+      }
     </div>
   </section>
 </main>

--- a/web-app/src/app/pages/cryptos/containers/account/account.component.html
+++ b/web-app/src/app/pages/cryptos/containers/account/account.component.html
@@ -38,6 +38,35 @@
       </app-crypto-filter>
     </div>
 
+    <div class="flex flex-wrap items-center gap-3 mb-4">
+      <div class="flex items-center gap-2">
+        <label class="text-sm text-gray-600 dark:text-gray-400">From</label>
+        <input type="date" [value]="startDate()" (change)="onStartDateChange($event)"
+          class="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-blue-500 focus:border-blue-500" />
+      </div>
+      <div class="flex items-center gap-2">
+        <label class="text-sm text-gray-600 dark:text-gray-400">To</label>
+        <input type="date" [value]="endDate()" (change)="onEndDateChange($event)"
+          class="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-blue-500 focus:border-blue-500" />
+      </div>
+      <div class="flex items-center gap-2">
+        <label class="text-sm text-gray-600 dark:text-gray-400">Status</label>
+        <select [value]="currentStatus()" (change)="onStatusChange($event)"
+          class="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-blue-500 focus:border-blue-500">
+          <option value="">All</option>
+          <option value="completed">Completed</option>
+          <option value="failed">Failed</option>
+          <option value="pending">Pending</option>
+        </select>
+      </div>
+      @if (startDate() || endDate()) {
+      <button (click)="clearDateFilters()"
+        class="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
+        Clear dates
+      </button>
+      }
+    </div>
+
     <div
       class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
       <app-account-transaction-card [groupedTransactionsNew]="account().groupedAccountTransactions">

--- a/web-app/src/app/pages/cryptos/containers/account/account.component.ts
+++ b/web-app/src/app/pages/cryptos/containers/account/account.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import { CryptoFilterComponent } from '../../components/crypto-filter/crypto-filter.component';
 import { CommonModule } from '@angular/common';
 import { AccountTransactionCardComponent } from '../../components/account-transaction-card/account-transaction-card.component';
@@ -9,6 +9,7 @@ import { DepositComponent } from '../deposit/deposit.component';
 import { DepositFundCommand, WithdrawFundCommand } from 'src/app/core/models/deposit-fund-command';
 import { WithdrawComponent } from '../withdraw/withdraw.component';
 import { AccountService } from 'src/app/core/services/account.service';
+import { Subject, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 export type AccountTransaction = {
   imageUrl: string;
   transactionType: AccountTransactionType;
@@ -43,25 +44,57 @@ export enum AccountTransactionType {
   ],
   templateUrl: './account.component.html',
 })
-export class AccountComponent implements OnInit {
+export class AccountComponent implements OnInit, OnDestroy {
   private accountService = inject(AccountService);
+  private unsubscribe$ = new Subject<void>();
 
   isDepositModalOpen = signal<boolean>(false);
   isWithdrawModalOpen = signal<boolean>(false);
   account = signal<AccountDto>({} as AccountDto);
+  currentPage = signal(1);
+  pageSize = 20;
+  currentFilter = signal('');
+
   ngOnInit(): void {
-    this.accountService.getSelectedAccount().subscribe({
+    this.loadAccountDetails();
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  loadAccountDetails(): void {
+    this.accountService.getSelectedAccount(this.currentPage(), this.pageSize, this.currentFilter()).subscribe({
       next: (result) => {
         if (result) {
           this.account.set(result);
         }
       },
-      error: (err) => { console.log(err) }
-    })
+      error: (err) => { console.log(err); }
+    });
   }
 
-  searchTransactions(input: any) {
-    console.log(input);
+  searchTransactions(input: string): void {
+    this.currentFilter.set(input);
+    this.currentPage.set(1);
+    this.loadAccountDetails();
+  }
+
+  nextPage(): void {
+    if (!this.account().hasNextPage) return;
+    this.currentPage.update((p) => p + 1);
+    this.loadAccountDetails();
+  }
+
+  previousPage(): void {
+    if (!this.account().hasPreviousPage) return;
+    this.currentPage.update((p) => p - 1);
+    this.loadAccountDetails();
+  }
+
+  totalPages(): number {
+    return Math.ceil(this.account().totalCount / this.pageSize);
   }
 
   toggleDepositModal() {

--- a/web-app/src/app/pages/cryptos/containers/account/account.component.ts
+++ b/web-app/src/app/pages/cryptos/containers/account/account.component.ts
@@ -54,6 +54,9 @@ export class AccountComponent implements OnInit, OnDestroy {
   currentPage = signal(1);
   pageSize = 20;
   currentFilter = signal('');
+  startDate = signal<string>('');
+  endDate = signal<string>('');
+  currentStatus = signal<string>('');
 
   ngOnInit(): void {
     this.loadAccountDetails();
@@ -65,7 +68,14 @@ export class AccountComponent implements OnInit, OnDestroy {
   }
 
   loadAccountDetails(): void {
-    this.accountService.getSelectedAccount(this.currentPage(), this.pageSize, this.currentFilter()).subscribe({
+    this.accountService.getSelectedAccount(
+      this.currentPage(),
+      this.pageSize,
+      this.currentFilter(),
+      this.startDate() || undefined,
+      this.endDate() || undefined,
+      this.currentStatus() || undefined
+    ).subscribe({
       next: (result) => {
         if (result) {
           this.account.set(result);
@@ -77,6 +87,34 @@ export class AccountComponent implements OnInit, OnDestroy {
 
   searchTransactions(input: string): void {
     this.currentFilter.set(input);
+    this.currentPage.set(1);
+    this.loadAccountDetails();
+  }
+
+  onStartDateChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.startDate.set(input.value);
+    this.currentPage.set(1);
+    this.loadAccountDetails();
+  }
+
+  onEndDateChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.endDate.set(input.value);
+    this.currentPage.set(1);
+    this.loadAccountDetails();
+  }
+
+  clearDateFilters(): void {
+    this.startDate.set('');
+    this.endDate.set('');
+    this.currentPage.set(1);
+    this.loadAccountDetails();
+  }
+
+  onStatusChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    this.currentStatus.set(select.value);
     this.currentPage.set(1);
     this.loadAccountDetails();
   }


### PR DESCRIPTION
## Issue #207

Refactor the account transaction card to:
- Display transaction date and time
- Display the latest transactions first
- Add filters
- Add pagination

## Changes

### Backend
- **`GetAccountDetailsQuery`**: Added `Page`, `PageSize`, and `Filter` parameters. Text filter searches across exchange name, notes, crypto symbol, and transaction type. Transactions within each date group are sorted by Date descending (latest first).
- **`AccountDto`**: Added pagination metadata fields (`TotalCount`, `Page`, `PageSize`, `HasNextPage`, `HasPreviousPage`).
- **`AccountController`**: Updated `account-details` endpoint to accept `page`, `pageSize`, and `filter` query params.
- Removed caching from the query handler (pagination + filtering makes caching impractical).

### Frontend
- **`AccountDto` interface**: Updated with pagination fields.
- **`AccountService`**: `getSelectedAccount()` now accepts page, pageSize, and filter params via `HttpParams`.
- **`AccountComponent`**: Implements `searchTransactions` filter, `nextPage`/`previousPage` navigation, and reloads on filter/page changes. Resets to page 1 when filter changes.
- **`AccountComponent` HTML**: Added pagination controls (Previous/Next buttons with page indicator) shown when there are more than `pageSize` transactions.
- **`AccountTransactionCardComponent` HTML**: Added time display (`h:mm a`) below each transaction type label.

Closes #207