### PR TITLE
feat: add CoinMarketCap attribution on main page

### DIFF
--- a/web-app/src/app/pages/cryptos/containers/view-cryptos/view-cryptos.component.html
+++ b/web-app/src/app/pages/cryptos/containers/view-cryptos/view-cryptos.component.html
@@ -44,6 +44,10 @@
         [sortOrder]="sortOrderOutput()" [sortBy]="sortByOutput()" (outputHeader)="outputHeaderEvent($event)" />
     </div>
   </div>
+
+  <p class="text-xs text-gray-400 dark:text-gray-500 mt-4">
+    Data provided by <a href="https://coinmarketcap.com" target="_blank" rel="noopener" class="underline hover:text-gray-600 dark:hover:text-gray-300">CoinMarketCap</a>
+  </p>
 </div>
 
 @if (isModalOpen()) {


### PR DESCRIPTION
Add 'Data provided by CoinMarketCap' link at the bottom of the portfolio dashboard page.

The link opens in a new tab with `rel="noopener"` for security.

Closes #179