### PR TITLE
feat: add 1Y and All timeframes to market value chart

### DIFF
--- a/api/api/Cryptos/Models/ETimeframe.cs
+++ b/api/api/Cryptos/Models/ETimeframe.cs
@@ -5,5 +5,6 @@ public enum ETimeframe
     _7d = 2,
     _1m = 3,
     _1y = 4,
-    All = 5
+    _3m = 5,
+    _6m = 6
 }

--- a/api/api/Cryptos/Queries/GetMarketDataByTimeframeQuery.cs
+++ b/api/api/Cryptos/Queries/GetMarketDataByTimeframeQuery.cs
@@ -42,6 +42,7 @@ public class GetMarketDataByTimeframeQueryHandler : IRequestHandler<GetMarketDat
             ETimeframe._7d => (now_aligned - 604800) / 86400 * 86400,  // Align to day boundary
             ETimeframe._1m => (now_aligned - 2592000) / 86400 * 86400,  // Align to day boundary
             ETimeframe._1y => now_aligned_month - (12 * oneMonthInterval),  // Align to month boundary
+            ETimeframe.All => 0,
             _ => throw new ArgumentOutOfRangeException("time frame not supported")
         };
 

--- a/api/api/Cryptos/Queries/GetMarketDataByTimeframeQuery.cs
+++ b/api/api/Cryptos/Queries/GetMarketDataByTimeframeQuery.cs
@@ -42,7 +42,8 @@ public class GetMarketDataByTimeframeQueryHandler : IRequestHandler<GetMarketDat
             ETimeframe._7d => (now_aligned - 604800) / 86400 * 86400,  // Align to day boundary
             ETimeframe._1m => (now_aligned - 2592000) / 86400 * 86400,  // Align to day boundary
             ETimeframe._1y => now_aligned_month - (12 * oneMonthInterval),  // Align to month boundary
-            ETimeframe.All => 0,
+            ETimeframe._3m => (now_aligned - (90 * 86400)) / 86400 * 86400,
+            ETimeframe._6m => (now_aligned - (180 * 86400)) / 86400 * 86400,
             _ => throw new ArgumentOutOfRangeException("time frame not supported")
         };
 
@@ -144,25 +145,41 @@ public class GetMarketDataByTimeframeQueryHandler : IRequestHandler<GetMarketDat
                 }
             }
         }
-        else // ETimeframe.All
+        else if (request.Timeframe == ETimeframe._3m)
         {
-            groupedData = snapshots
-                .Where(x => x.Time >= startTime && x.Time <= now_aligned)
-                .GroupBy(x =>
+            const long oneDayInterval = 86400;
+            groupedData = new List<MarketDataPointDto>();
+            for (var time = startTime; time < now_aligned; time += oneDayInterval)
+            {
+                var bucketStart = (time / oneDayInterval) * oneDayInterval;
+                var bucketEnd = bucketStart + oneDayInterval;
+                var lastSnapshot = snapshots
+                    .Where(s => s.Time >= bucketStart && s.Time < bucketEnd)
+                    .OrderByDescending(s => s.Time)
+                    .FirstOrDefault();
+                if (lastSnapshot != null)
                 {
-                    var date = DateTimeOffset.FromUnixTimeSeconds(x.Time).UtcDateTime;
-                    // Start of the month
-                    return new DateTime(date.Year, date.Month, 1);
-                })
-                .SelectMany(group =>
+                    groupedData.Add(new MarketDataPointDto(bucketStart, lastSnapshot.Value));
+                }
+            }
+        }
+        else // ETimeframe._6m
+        {
+            const long oneWeekInterval = 7 * 86400;
+            groupedData = new List<MarketDataPointDto>();
+            for (var time = startTime; time < now_aligned; time += oneWeekInterval)
+            {
+                var bucketStart = (time / oneWeekInterval) * oneWeekInterval;
+                var bucketEnd = bucketStart + oneWeekInterval;
+                var lastSnapshot = snapshots
+                    .Where(s => s.Time >= bucketStart && s.Time < bucketEnd)
+                    .OrderByDescending(s => s.Time)
+                    .FirstOrDefault();
+                if (lastSnapshot != null)
                 {
-                    var monthStartTimestamp = new DateTimeOffset(group.Key).ToUnixTimeSeconds();
-                    return group
-                        .OrderBy(x => x.Time)
-                        .Select(x => new MarketDataPointDto(monthStartTimestamp, x.Value));
-                })
-                .OrderBy(x => x.Time)
-                .ToList();
+                    groupedData.Add(new MarketDataPointDto(bucketStart, lastSnapshot.Value));
+                }
+            }
         }
 
         return Result<IEnumerable<MarketDataPointDto>>.Success(groupedData);

--- a/api/api/Services/TimeframeCalculator.cs
+++ b/api/api/Services/TimeframeCalculator.cs
@@ -18,7 +18,8 @@ public class TimeframeCalculator : ITimeframeCalculator
             ETimeframe._7d => now - (7 * SecondsPerDay),
             ETimeframe._1m => now - (30 * SecondsPerDay),
             ETimeframe._1y => now - (365 * SecondsPerDay),
-            ETimeframe.All => 0,
+            ETimeframe._3m => now - (90 * SecondsPerDay),
+            ETimeframe._6m => now - (180 * SecondsPerDay),
             _ => throw new ArgumentException("Invalid timeframe", nameof(timeframe))
         };
     }
@@ -31,7 +32,8 @@ public class TimeframeCalculator : ITimeframeCalculator
             ETimeframe._7d => SecondsPerDay,      // Group by day
             ETimeframe._1m => SecondsPerDay,      // Group by day
             ETimeframe._1y => SecondsPerMonth,    // Group by month
-            ETimeframe.All => SecondsPerYear,     // Group by year
+            ETimeframe._3m => SecondsPerDay,      // Group by day
+            ETimeframe._6m => 7 * SecondsPerDay,  // Group by week
             _ => throw new ArgumentException("Invalid timeframe", nameof(timeframe))
         };
     }

--- a/web-app/src/app/core/services/crypto.service.ts
+++ b/web-app/src/app/core/services/crypto.service.ts
@@ -124,5 +124,6 @@ export enum ETimeframe {
   _7d = 2,
   _1m = 3,
   _1y = 4,
-  All = 5,
+  _3m = 5,
+  _6m = 6,
 }

--- a/web-app/src/app/core/services/crypto.service.ts
+++ b/web-app/src/app/core/services/crypto.service.ts
@@ -123,4 +123,6 @@ export enum ETimeframe {
   _24h = 1,
   _7d = 2,
   _1m = 3,
+  _1y = 4,
+  All = 5,
 }

--- a/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.cy.ts
+++ b/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.cy.ts
@@ -8,7 +8,14 @@ const mockMarketData = {
   ],
 }
 
-const timeframeLabels = ['24H', '7D', '1M', '1Y', 'All']
+const timeframeLabels = [
+  { label: '24H', value: 1 },
+  { label: '7D', value: 2 },
+  { label: '1M', value: 3 },
+  { label: '3M', value: 5 },
+  { label: '6M', value: 6 },
+  { label: '1Y', value: 4 },
+]
 
 describe('LineChartComponent', () => {
   beforeEach(() => {
@@ -24,10 +31,10 @@ describe('LineChartComponent', () => {
     cy.get('button').should('exist')
   })
 
-  it('should render all 5 timeframe buttons', () => {
+  it('should render all 6 timeframe buttons', () => {
     cy.mount(LineChartComponent)
     cy.wait('@marketData')
-    timeframeLabels.forEach((label) => {
+    timeframeLabels.forEach(({ label }) => {
       cy.contains('button', label).should('be.visible')
     })
   })
@@ -39,15 +46,15 @@ describe('LineChartComponent', () => {
     cy.get('@marketData.all').should('have.length', 1)
   })
 
-  timeframeLabels.forEach((label, index) => {
+  timeframeLabels.forEach(({ label, value }) => {
     it(`should fetch market data with correct timeframe when ${label} is clicked`, () => {
       cy.mount(LineChartComponent)
       cy.wait('@marketData')
 
       cy.contains('button', label).click()
 
-      if (index > 0) {
-        cy.wait('@marketData').its('request.url').should('contain', `timeframe=${index + 1}`)
+      if (value !== 1) {
+        cy.wait('@marketData').its('request.url').should('contain', `timeframe=${value}`)
       } else {
         cy.get('@marketData.all').should('have.length.at.least', 1)
       }
@@ -60,12 +67,12 @@ describe('LineChartComponent', () => {
     cy.mount(LineChartComponent)
     cy.wait('@marketData')
 
+    cy.contains('button', '3M').click()
+    cy.wait('@marketData')
+    cy.contains('h1', '3M Market Value').should('be.visible')
+
     cy.contains('button', '1Y').click()
     cy.wait('@marketData')
     cy.contains('h1', '1Y Market Value').should('be.visible')
-
-    cy.contains('button', 'All').click()
-    cy.wait('@marketData')
-    cy.contains('h1', 'All Market Value').should('be.visible')
   })
 })

--- a/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.cy.ts
+++ b/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.cy.ts
@@ -1,7 +1,71 @@
 import { LineChartComponent } from './line-chart.component'
 
+const mockMarketData = {
+  value: [
+    { time: 1753614000, value: 10000 },
+    { time: 1753617600, value: 10100 },
+    { time: 1753621200, value: 10050 },
+  ],
+}
+
+const timeframeLabels = ['24H', '7D', '1M', '1Y', 'All']
+
 describe('LineChartComponent', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/get-marketData-by-timeframe*', {
+      statusCode: 200,
+      body: mockMarketData,
+    }).as('marketData')
+  })
+
   it('should mount', () => {
     cy.mount(LineChartComponent)
+    cy.wait('@marketData')
+    cy.get('button').should('exist')
+  })
+
+  it('should render all 5 timeframe buttons', () => {
+    cy.mount(LineChartComponent)
+    cy.wait('@marketData')
+    timeframeLabels.forEach((label) => {
+      cy.contains('button', label).should('be.visible')
+    })
+  })
+
+  it('should default to 24H selected', () => {
+    cy.mount(LineChartComponent)
+    cy.wait('@marketData')
+    cy.contains('button', '24H').should('have.class', 'bg-gray-200')
+    cy.get('@marketData.all').should('have.length', 1)
+  })
+
+  timeframeLabels.forEach((label, index) => {
+    it(`should fetch market data with correct timeframe when ${label} is clicked`, () => {
+      cy.mount(LineChartComponent)
+      cy.wait('@marketData')
+
+      cy.contains('button', label).click()
+
+      if (index > 0) {
+        cy.wait('@marketData').its('request.url').should('contain', `timeframe=${index + 1}`)
+      } else {
+        cy.get('@marketData.all').should('have.length.at.least', 1)
+      }
+
+      cy.contains('button', label).should('have.class', 'bg-gray-200')
+    })
+  })
+
+  it('should display correct chart title after selecting timeframe', () => {
+    cy.mount(LineChartComponent)
+    cy.wait('@marketData')
+
+    cy.contains('button', '1Y').click()
+    cy.wait('@marketData')
+    cy.contains('h1', '1Y Market Value').should('be.visible')
+
+    cy.contains('button', 'All').click()
+    cy.wait('@marketData')
+    cy.contains('h1', 'All Market Value').should('be.visible')
   })
 })

--- a/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.ts
+++ b/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.ts
@@ -29,12 +29,16 @@ export class LineChartComponent implements AfterViewInit {
       time: ETimeframe._1m
     },
     {
-      description: '1Y',
-      time: ETimeframe._1y
+      description: '3M',
+      time: ETimeframe._3m
     },
     {
-      description: 'All',
-      time: ETimeframe.All
+      description: '6M',
+      time: ETimeframe._6m
+    },
+    {
+      description: '1Y',
+      time: ETimeframe._1y
     },
   ]);
   selectedTimeFilter = model<ETimeframe>(ETimeframe._24h);
@@ -42,8 +46,9 @@ export class LineChartComponent implements AfterViewInit {
     [ETimeframe._24h]: [],
     [ETimeframe._7d]: [],
     [ETimeframe._1m]: [],
+    [ETimeframe._3m]: [],
+    [ETimeframe._6m]: [],
     [ETimeframe._1y]: [],
-    [ETimeframe.All]: [],
   };
   lineChartInstance: any = null;
   lineChartTitle = signal('');
@@ -122,8 +127,8 @@ export class LineChartComponent implements AfterViewInit {
   private axisLabelFormatter(value: string, selectedTime: ETimeframe): string {
     const date = new Date(value);
     if (selectedTime === ETimeframe._24h) return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    if (selectedTime === ETimeframe._7d) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-    if (selectedTime === ETimeframe._1m) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    if (selectedTime === ETimeframe._7d || selectedTime === ETimeframe._1m || selectedTime === ETimeframe._3m) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    if (selectedTime === ETimeframe._6m) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
     return date.toLocaleDateString([], { month: 'short', year: 'numeric' });
   }
 }

--- a/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.ts
+++ b/web-app/src/app/pages/cryptos/components/line-chart/line-chart.component.ts
@@ -28,12 +28,22 @@ export class LineChartComponent implements AfterViewInit {
       description: '1M',
       time: ETimeframe._1m
     },
+    {
+      description: '1Y',
+      time: ETimeframe._1y
+    },
+    {
+      description: 'All',
+      time: ETimeframe.All
+    },
   ]);
   selectedTimeFilter = model<ETimeframe>(ETimeframe._24h);
   marketDataNew: MarketData = {
     [ETimeframe._24h]: [],
     [ETimeframe._7d]: [],
     [ETimeframe._1m]: [],
+    [ETimeframe._1y]: [],
+    [ETimeframe.All]: [],
   };
   lineChartInstance: any = null;
   lineChartTitle = signal('');
@@ -113,7 +123,8 @@ export class LineChartComponent implements AfterViewInit {
     const date = new Date(value);
     if (selectedTime === ETimeframe._24h) return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     if (selectedTime === ETimeframe._7d) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    if (selectedTime === ETimeframe._1m) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString([], { month: 'short', year: 'numeric' });
   }
 }
 


### PR DESCRIPTION
Added 1 Year and All time options to the market value line chart.

The backend already supported these timeframes, they just weren't exposed in the UI. The x-axis uses month + year labels for these longer timeframes.

**Changes:**
- Added `_1y` and `All` to frontend `ETimeframe` enum
- Added 1Y and All buttons to the chart's timeframe selector
- Updated axis label formatter for month+year display on longer ranges

Closes #178