### PR TITLE
ci: run EF Core migrations after backend deploy

### DIFF
--- a/.github/workflows/full-stack-deployment.yml
+++ b/.github/workflows/full-stack-deployment.yml
@@ -117,7 +117,7 @@ jobs:
           dotnet-version: "8.x"
 
       - name: Install dotnet-ef tool
-        run: dotnet tool install --global dotnet-ef
+        run: dotnet tool install --global dotnet-ef --version 8.0.7
 
       - name: Apply database migrations
         env:

--- a/.github/workflows/full-stack-deployment.yml
+++ b/.github/workflows/full-stack-deployment.yml
@@ -101,6 +101,33 @@ jobs:
           package: .
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
 
+  migrate_database:
+    name: Apply EF Core Migrations
+    runs-on: ubuntu-latest
+    needs: deploy_backend
+    environment:
+      name: ${{ github.event.inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+
+      - name: Install dotnet-ef tool
+        run: dotnet tool install --global dotnet-ef
+
+      - name: Apply database migrations
+        env:
+          ConnectionStrings__DefaultConnection: ${{ secrets.CONNECTION_STRING }}
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet ef database update \
+            --project api/api/api.csproj \
+            --startup-project api/api/api.csproj
+
   deploy_frontend:
     name: Deploy Frontend to ${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest

--- a/api/api/Data/DataContextFactory.cs
+++ b/api/api/Data/DataContextFactory.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace api.Data;
+
+public class DataContextFactory : IDesignTimeDbContextFactory<DataContext>
+{
+    public DataContext CreateDbContext(string[] args)
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = config.GetConnectionString("DefaultConnection")
+            ?? config["ConnectionStrings__DefaultConnection"]
+            ?? throw new InvalidOperationException("Connection string 'DefaultConnection' is missing.");
+
+        var options = new DbContextOptionsBuilder<DataContext>()
+            .UseSqlServer(connectionString, x => x.EnableRetryOnFailure())
+            .Options;
+
+        return new DataContext(options);
+    }
+}


### PR DESCRIPTION
Adds a `migrate_database` job to the full-stack deployment pipeline that runs `dotnet ef database update` against the selected environment's DB right after the backend deploy.

**Setup required before this works:**
- Add a `CONNECTION_STRING` secret to each GitHub Environment (stage, production) pointing at that environment's Hetzner SQL Server
- Ensure port 1433 on the Hetzner host accepts connections from GitHub-hosted runners