### PR TITLE
ci: run database migrations before deploying backend

### DIFF
--- a/.github/workflows/full-stack-deployment.yml
+++ b/.github/workflows/full-stack-deployment.yml
@@ -77,7 +77,7 @@ jobs:
   deploy_backend:
     name: Deploy Backend
     runs-on: ubuntu-latest
-    needs: build_frontend
+    needs: [build_frontend, migrate_database]
     environment:
       name: ${{ github.event.inputs.environment }}
 
@@ -104,7 +104,7 @@ jobs:
   migrate_database:
     name: Apply EF Core Migrations
     runs-on: ubuntu-latest
-    needs: deploy_backend
+    needs: build_backend
     environment:
       name: ${{ github.event.inputs.environment }}
 


### PR DESCRIPTION
Move the EF Core migration step before the Azure Web App deploy so production traffic never hits a new backend that depends on a pending schema change.

**Before:** build_backend → build_frontend → deploy_backend → migrate_database (schema updated after traffic is live)
**After:** build_backend → build_frontend / migrate_database → deploy_backend