### PR TITLE
fix: align 6M market data buckets to week boundary

### DIFF
--- a/api/api/Cryptos/Queries/GetMarketDataByTimeframeQuery.cs
+++ b/api/api/Cryptos/Queries/GetMarketDataByTimeframeQuery.cs
@@ -167,9 +167,10 @@ public class GetMarketDataByTimeframeQueryHandler : IRequestHandler<GetMarketDat
         {
             const long oneWeekInterval = 7 * 86400;
             groupedData = new List<MarketDataPointDto>();
-            for (var time = startTime; time < now_aligned; time += oneWeekInterval)
+            // Advance using the aligned bucket cursor so buckets stay contiguous
+            // and the last bucket reaches now_aligned, including recent snapshots.
+            for (var bucketStart = (startTime / oneWeekInterval) * oneWeekInterval; bucketStart < now_aligned; bucketStart += oneWeekInterval)
             {
-                var bucketStart = (time / oneWeekInterval) * oneWeekInterval;
                 var bucketEnd = bucketStart + oneWeekInterval;
                 var lastSnapshot = snapshots
                     .Where(s => s.Time >= bucketStart && s.Time < bucketEnd)


### PR DESCRIPTION
Fixes stale chart data on the 6M timeframe.

**Problem:** The 6M loop advanced from the day-aligned `startTime` but re-floored each iteration to a Unix-week boundary. When `startTime` is not already on a week boundary, the last floored bucket can end before `now_aligned`, leaving the most recent snapshots outside every `s.Time < bucketEnd` check.

**Fix:** Drive the loop from the aligned bucket cursor (`(startTime / oneWeekInterval) * oneWeekInterval`) so buckets are contiguous through the present and the final bucket includes recent snapshots.