### PR TITLE
ci: deploy Azure Functions in full-stack pipeline

### DIFF
--- a/.github/workflows/full-stack-deployment.yml
+++ b/.github/workflows/full-stack-deployment.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           name: .functions-app
           path: ${{ runner.temp }}/functions-app
+          include-hidden-files: true
 
   deploy_backend:
     name: Deploy Backend

--- a/.github/workflows/full-stack-deployment.yml
+++ b/.github/workflows/full-stack-deployment.yml
@@ -74,6 +74,28 @@ jobs:
           name: .web-app
           path: web-app/dist
 
+  build_functions:
+    name: Build Azure Functions
+    runs-on: ubuntu-latest
+    needs: build_backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+
+      - name: Publish Azure Functions
+        run: dotnet publish api/functions/functions.csproj -c Release -o ${{ runner.temp }}/functions-app
+
+      - name: Upload Functions artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: .functions-app
+          path: ${{ runner.temp }}/functions-app
+
   deploy_backend:
     name: Deploy Backend
     runs-on: ubuntu-latest
@@ -128,10 +150,31 @@ jobs:
             --project api/api/api.csproj \
             --startup-project api/api/api.csproj
 
+  deploy_functions:
+    name: Deploy Azure Functions
+    runs-on: ubuntu-latest
+    needs: [build_functions, migrate_database]
+    environment:
+      name: ${{ github.event.inputs.environment }}
+
+    steps:
+      - name: Download Functions artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: .functions-app
+
+      - name: Deploy to Azure Function App
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ secrets.AZURE_FUNCTION_NAME }}
+          slot-name: "Production"
+          package: .
+          publish-profile: ${{ secrets.AZURE_FUNCTION_APP_TOKEN }}
+
   deploy_frontend:
     name: Deploy Frontend to ${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
-    needs: deploy_backend
+    needs: [deploy_backend, deploy_functions]
     environment:
       name: ${{ github.event.inputs.environment }}
 


### PR DESCRIPTION
## Summary

Integrates Azure Functions build and deployment into the full-stack deployment workflow.

## Deployment order

`build_backend` now fans out to `build_frontend`, `build_functions`, and `migrate_database`. The Function App and API deploy only after migrations complete; frontend deployment waits for both runtime services.

`build_backend → migrate_database → deploy_backend / deploy_functions → deploy_frontend`

## Changes

- Publish `api/functions/functions.csproj` as a dedicated `.functions-app` artifact.
- Deploy it with `Azure/functions-action@v1` using the existing environment secrets `AZURE_FUNCTION_NAME` and `AZURE_FUNCTION_APP_TOKEN`.
- Gate Function deployment behind `migrate_database` so timer jobs cannot run against a pending schema change.
- Require both API and Function App deployment before frontend deployment.

## Verification

- Workflow YAML parses successfully.
- `dotnet publish api/functions/functions.csproj -c Release` succeeds locally.